### PR TITLE
Fix prayer API encoding and Quran search results

### DIFF
--- a/src/services/islamicApi.ts
+++ b/src/services/islamicApi.ts
@@ -5,7 +5,9 @@ const QURAN_API = 'https://api.alquran.cloud/v1';
 
 export const getPrayerTimes = async (city: string): Promise<{ city: string; times: PrayerTimes; date: string } | null> => {
   try {
-    const response = await fetch(`${ALADHAN_API}/timingsByCity?city=${city}&country=Indonesia`);
+    const response = await fetch(
+      `${ALADHAN_API}/timingsByCity?city=${encodeURIComponent(city)}&country=Indonesia`
+    );
     const data = await response.json();
     
     if (data.code === 200) {
@@ -121,7 +123,7 @@ export const searchQuran = async (query: string): Promise<QuranSearchResult[]> =
             englishName: match.surah.englishName
           }
         },
-        matches: [query]
+        matches: match.matches ? match.matches : [match.text]
       }));
     }
     return [];


### PR DESCRIPTION
## Summary
- encode city names when fetching prayer times
- improve Quran search API results by using API-provided matches instead of the query text

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6870e5e4f07c832cb7820d5848f90993