### PR TITLE
Add vitest with initial test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -28,6 +29,7 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/services/islamicApi.test.ts
+++ b/src/services/islamicApi.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { getQiblaDirection } from './islamicApi';
+
+describe('getQiblaDirection', () => {
+  it('returns the correct Google Maps URL and a numeric bearing', () => {
+    const result = getQiblaDirection(0, 0);
+    expect(result.url).toBe('https://www.google.com/maps/dir/0,0/21.4225,39.8262');
+    expect(typeof result.bearing).toBe('number');
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest dev dependency and npm test script
- add unit test for `getQiblaDirection`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6870e8c63a78832c85992464e0d32a46